### PR TITLE
feat: cache npm with volta

### DIFF
--- a/.github/actions/npm-prepare/action.yml
+++ b/.github/actions/npm-prepare/action.yml
@@ -13,6 +13,17 @@ runs:
       shell: bash
       run: |
         echo "//npm.pkg.github.com/:_authToken=${GITHUB_NPM_TOKEN}" >> .npmrc
+    - name: Cache npm cache
+      uses: actions/cache@v2
+      env:
+        cache-name: npm-cache
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-${{ github.repository }}-test-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ github.repository }}-test-${{ env.cache-name }}-
+          ${{ runner.os }}-${{ github.repository }}-test-
+          ${{ runner.os }}-${{ github.repository }}-
     - name: Install modules
       shell: bash
       run: npm ci

--- a/.github/actions/npm-prepare/action.yml
+++ b/.github/actions/npm-prepare/action.yml
@@ -19,10 +19,9 @@ runs:
         cache-name: npm-cache
       with:
         path: ~/.npm
-        key: ${{ runner.os }}-${{ github.repository }}-test-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        key: ${{ runner.os }}-${{ github.repository }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
-          ${{ runner.os }}-${{ github.repository }}-test-${{ env.cache-name }}-
-          ${{ runner.os }}-${{ github.repository }}-test-
+          ${{ runner.os }}-${{ github.repository }}-${{ env.cache-name }}-
           ${{ runner.os }}-${{ github.repository }}-
     - name: Install modules
       shell: bash


### PR DESCRIPTION
Restored this from here: https://github.com/parachutehome/workflows/commit/d9fc3f92c6f54b5e4ef7e5d637b4c787a2512e97

It was taken out when we switched to Github's setup node. But then caching was lost when we moved to Volta's action.